### PR TITLE
Fix table rendering with terminals less than 90 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed table rendering with terminals less than 90 chars
+  (#[33](https://github.com/asomers/ztop/pull/33))
+
 - Removed dependency on unmaintained tui crate.
   ([RUSTSEC-2023-0049](https://rustsec.org/advisories/RUSTSEC-2023-0049))
   Removed dependency on atty crate, fixing an unaligned read bug.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +22,12 @@ checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstream"
@@ -179,6 +197,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +256,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lru"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +292,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "parking_lot"
@@ -305,15 +348,16 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
+checksum = "0ebc917cfb527a566c37ecb94c7e3fd098353516fb4eb6bea17015ade0182425"
 dependencies = [
  "bitflags 2.4.0",
  "cassowary",
  "crossterm",
  "indoc",
  "itertools",
+ "lru",
  "paste",
  "strum",
  "unicode-segmentation",
@@ -500,6 +544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +662,26 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "ztop"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,8 +348,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.24.0"
-source = "git+https://github.com/asomers/ratatui?rev=3d2d451#3d2d451ecd54ddb4106d2ee3c47abe3fdfb01563"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
 dependencies = [
  "bitflags 2.4.0",
  "cassowary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,18 +687,18 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.28"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.28"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -226,9 +226,9 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]
@@ -349,8 +349,7 @@ dependencies = [
 [[package]]
 name = "ratatui"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebc917cfb527a566c37ecb94c7e3fd098353516fb4eb6bea17015ade0182425"
+source = "git+https://github.com/asomers/ratatui?rev=3d2d451#3d2d451ecd54ddb4106d2ee3c47abe3fdfb01563"
 dependencies = [
  "bitflags 2.4.0",
  "cassowary",
@@ -359,6 +358,7 @@ dependencies = [
  "itertools",
  "lru",
  "paste",
+ "stability",
  "strum",
  "unicode-segmentation",
  "unicode-width",
@@ -448,6 +448,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
+name = "stability"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,7 +482,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -516,7 +537,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -680,7 +701,7 @@ checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ humanize-rs = "0.1.5"
 nix = { version = "0.27.0", default-features = false, features = ["time"] }
 sysctl = "0.4.2"
 crossterm = { version = "0.27.0", default-features = false , features = ["events"]}
-ratatui = { version = "0.23.0", default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.24.0", default-features = false, features = ["crossterm"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glob = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ humanize-rs = "0.1.5"
 nix = { version = "0.27.0", default-features = false, features = ["time"] }
 sysctl = "0.4.2"
 crossterm = { version = "0.27.0", default-features = false , features = ["events"]}
-ratatui = { version = "0.24.0", default-features = false, features = ["crossterm", "unstable"] }
+ratatui = { version = "0.25.0", default-features = false, features = ["crossterm", "unstable"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glob = "0.3"
@@ -27,6 +27,3 @@ version = "1.3"
 default-features = false
 # Disable the unicode feature, since dataset names are always ASCII
 features = [ "perf", "std" ]
-
-[patch.crates-io]
-ratatui = { git = "https://github.com/asomers/ratatui", rev = "3d2d451" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ humanize-rs = "0.1.5"
 nix = { version = "0.27.0", default-features = false, features = ["time"] }
 sysctl = "0.4.2"
 crossterm = { version = "0.27.0", default-features = false , features = ["events"]}
-ratatui = { version = "0.24.0", default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.24.0", default-features = false, features = ["crossterm", "unstable"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glob = "0.3"
@@ -27,3 +27,6 @@ version = "1.3"
 default-features = false
 # Disable the unicode feature, since dataset names are always ASCII
 features = [ "perf", "std" ]
+
+[patch.crates-io]
+ratatui = { git = "https://github.com/asomers/ratatui", rev = "3d2d451" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,11 +154,10 @@ mod ui {
             Constraint::Length(7),
             Constraint::Min(6),
         ];
-        let t = Table::new(rows)
+        let t = Table::new(rows, widths)
             .header(header)
             .block(Block::default())
-            .segment_size(ratatui::layout::SegmentSize::LastTakesRemainder)
-            .widths(widths);
+            .segment_size(ratatui::layout::SegmentSize::LastTakesRemainder);
         f.render_widget(t, f.size());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ impl FilterPopup {
 }
 
 mod ui {
-    use ratatui::{backend::Backend, Frame};
+    use ratatui::Frame;
 
     use super::*;
 
@@ -108,7 +108,7 @@ mod ui {
             .split(popup_layout[1])[1]
     }
 
-    pub fn draw<B: Backend>(f: &mut Frame<B>, app: &mut App) {
+    pub fn draw(f: &mut Frame, app: &mut App) {
         let hstyle = Style::default().fg(Color::Red);
         let sstyle = hstyle.add_modifier(Modifier::REVERSED);
         let hcells = [
@@ -162,7 +162,7 @@ mod ui {
     }
 
     #[rustfmt::skip]
-    pub fn draw_filter<B: Backend>(f: &mut Frame<B>, app: &FilterPopup) {
+    pub fn draw_filter(f: &mut Frame, app: &FilterPopup) {
         let area = popup_layout(40, 3, f.size());
         let popup_box = Paragraph::new(app.new_regex.as_str())
             .block(

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,12 +152,13 @@ mod ui {
             Constraint::Length(8),
             Constraint::Length(7),
             Constraint::Length(7),
-            Constraint::Min(40),
+            Constraint::Min(6),
         ];
         let t = Table::new(rows)
             .header(header)
             .block(Block::default())
-            .widths(&widths);
+            .segment_size(ratatui::layout::SegmentSize::LastTakesRemainder)
+            .widths(widths);
         f.render_widget(t, f.size());
     }
 


### PR DESCRIPTION
Fix table rendering with terminals less than 90 chars
    
Previously, when the terminal was less than about 90 chars wide ratatui would shrink or even disappear one of the data columns, seemingly at random.  This was a regression from tui, which would always shrink the final column.
    
Now, ztop will always display a minimum of 6 chars for the Dataset column, and shrink a data column (again, at random) only for very narrow terminals.
    
Fixes #32

Depends on https://github.com/ratatui-org/ratatui/pull/660 
