### PR TITLE
Fix cargo audit in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,7 +45,7 @@ task:
     - cargo fmt --all -- --check --color=never
   audit_script:
     - . $HOME/.cargo/env
-    - pkg install -y cargo-audit
+    - cargo install --version=0.17.6 cargo-audit
     - cargo audit
   # Test our minimal version spec
   minver_test_script:


### PR DESCRIPTION
cargo-audit 0.18.3 does not work in Cirrus's environment

* https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276557
* https://github.com/rustsec/rustsec/issues/1058