### PR TITLE
Correctly reset the terminal when quitting the application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Correctly reset terminal settings when quitting the application.
+  (#[38](https://github.com/asomers/gstat-rs/pull/38))
+
 ## [0.2.3] - 2023-12-18
 
 ### Fixed

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,5 +293,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
     terminal.set_cursor(0, crossterm::terminal::size()?.1 - 1)?;
+    crossterm::terminal::disable_raw_mode().unwrap();
     Ok(())
 }


### PR DESCRIPTION
When quitting the application, reset the terminal settings. This is necessary for bash and ksh93, but not for sh, csh, tcsh, and fish.

Fixes #37