### PR TITLE
Change the meaning of "-d" to match the behavior of "zfs list"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed the `-d` switch to match the behavior of `zfs list -d`: A depth of 0
+  means to display each pool, a depth of 1 means to display one dataset deeper,
+  etc.
+  (#[55](https://github.com/asomers/gstat-rs/pull/55))
+
 - Tweaked colors for better visibility on some terminals.
   (#[48](https://github.com/asomers/gstat-rs/pull/48))
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,6 @@ use std::{
     collections::{btree_map, BTreeMap},
     error::Error,
     mem,
-    num::NonZeroUsize,
     ops::AddAssign,
 };
 
@@ -237,7 +236,7 @@ pub struct Element {
 pub struct App {
     auto:        bool,
     data:        DataSource,
-    depth:       Option<NonZeroUsize>,
+    depth:       Option<usize>,
     filter:      Option<Regex>,
     reverse:     bool,
     should_quit: bool,
@@ -250,7 +249,7 @@ impl App {
         auto: bool,
         children: bool,
         pools: Vec<String>,
-        depth: Option<NonZeroUsize>,
+        depth: Option<usize>,
         filter: Option<Regex>,
         reverse: bool,
         sort_idx: Option<usize>,
@@ -281,8 +280,8 @@ impl App {
         let mut v = self.data.iter()
             .filter(move |elem| {
                 if let Some(limit) = depth {
-                    let edepth = elem.name.split('/').count();
-                    edepth <= limit.get()
+                    let edepth = elem.name.split('/').count() - 1;
+                    edepth <= limit
                 } else {
                     true
                 }
@@ -324,13 +323,13 @@ impl App {
     pub fn on_d(&mut self, more_depth: bool) {
         self.depth = if more_depth {
             match self.depth {
-                None => NonZeroUsize::new(1),
-                Some(x) => NonZeroUsize::new(x.get() + 1),
+                None => Some(1),
+                Some(x) => Some(x + 1),
             }
         } else {
             match self.depth {
-                None => None,
-                Some(x) => NonZeroUsize::new(x.get() - 1),
+                None => Some(0),
+                Some(x) => Some(x.saturating_sub(1)),
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 // vim: tw=80
-use std::{error::Error, io, num::NonZeroUsize, time::Duration};
+use std::{error::Error, io, time::Duration};
 
 use clap::Parser;
 use crossterm::event::KeyCode;
@@ -29,7 +29,7 @@ struct Cli {
     children: bool,
     /// display datasets no more than this many levels deep.
     #[clap(short = 'd', long = "depth")]
-    depth:    Option<NonZeroUsize>,
+    depth:    Option<usize>,
     /// only display datasets with names matching filter, as a regex.
     #[clap(short = 'f', value_parser = Regex::new, long = "filter")]
     filter:   Option<Regex>,


### PR DESCRIPTION
A value of 0 means to display each pool.  1 means one dataset deeper, etc.