### PR TITLE
Change the default sort direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed the default sort order.  By default, sort descending for numeric
+  columns or ascending for dataset name.
+  (#[56](https://github.com/asomers/gstat-rs/pull/56))
+
 - Changed the `-d` switch to match the behavior of `zfs list -d`: A depth of 0
   means to display each pool, a depth of 1 means to display one dataset deeper,
   etc.

--- a/src/app.rs
+++ b/src/app.rs
@@ -293,20 +293,20 @@ impl App {
                      (elem.r_s + elem.w_s + elem.ops_unlink > 1.0)
             ).collect::<Vec<_>>();
         match (self.reverse, self.sort_idx) {
-            (false, Some(0)) => v.sort_by(|x, y| x.ops_r.total_cmp(&y.ops_r)),
-            (true,  Some(0)) => v.sort_by(|x, y| y.ops_r.total_cmp(&x.ops_r)),
-            (false, Some(1)) => v.sort_by(|x, y| x.r_s.total_cmp(&y.r_s)),
-            (true,  Some(1)) => v.sort_by(|x, y| y.r_s.total_cmp(&x.r_s)),
-            (false, Some(2)) => v.sort_by(|x, y| x.ops_w.total_cmp(&y.ops_w)),
-            (true,  Some(2)) => v.sort_by(|x, y| y.ops_w.total_cmp(&x.ops_w)),
-            (false, Some(3)) => v.sort_by(|x, y| x.w_s.total_cmp(&y.w_s)),
-            (true,  Some(3)) => v.sort_by(|x, y| y.w_s.total_cmp(&x.w_s)),
-            (false, Some(4)) => v.sort_by(|x, y|
+            (true, Some(0)) => v.sort_by(|x, y| x.ops_r.total_cmp(&y.ops_r)),
+            (false,  Some(0)) => v.sort_by(|x, y| y.ops_r.total_cmp(&x.ops_r)),
+            (true, Some(1)) => v.sort_by(|x, y| x.r_s.total_cmp(&y.r_s)),
+            (false,  Some(1)) => v.sort_by(|x, y| y.r_s.total_cmp(&x.r_s)),
+            (true, Some(2)) => v.sort_by(|x, y| x.ops_w.total_cmp(&y.ops_w)),
+            (false,  Some(2)) => v.sort_by(|x, y| y.ops_w.total_cmp(&x.ops_w)),
+            (true, Some(3)) => v.sort_by(|x, y| x.w_s.total_cmp(&y.w_s)),
+            (false,  Some(3)) => v.sort_by(|x, y| y.w_s.total_cmp(&x.w_s)),
+            (true, Some(4)) => v.sort_by(|x, y|
                 x.ops_unlink.total_cmp(&y.ops_unlink)),
-            (true,  Some(4)) => v.sort_by(|x, y|
+            (false,  Some(4)) => v.sort_by(|x, y|
                 y.ops_unlink.total_cmp(&x.ops_unlink)),
-            (false, Some(6)) => v.sort_by(|x, y| x.name.cmp(&y.name)),
-            (true,  Some(6)) => v.sort_by(|x, y| y.name.cmp(&x.name)),
+            (false, Some(5)) => v.sort_by(|x, y| x.name.cmp(&y.name)),
+            (true,  Some(5)) => v.sort_by(|x, y| y.name.cmp(&x.name)),
             _ => ()
         }
         v
@@ -338,13 +338,13 @@ impl App {
         self.sort_idx = match self.sort_idx {
             Some(0) => None,
             Some(old) => Some(old - 1),
-            None => Some(6),
+            None => Some(5),
         }
     }
 
     pub fn on_plus(&mut self) {
         self.sort_idx = match self.sort_idx {
-            Some(old) if old >= 6 => None,
+            Some(old) if old >= 5 => None,
             Some(old) => Some(old + 1),
             None => Some(0),
         }


### PR DESCRIPTION
By default, sort descending for numeric columns or ascending for dataset name.  This is the most useful sort order, IMHO.

Also, fix sorting by dataset name, broken since #53.